### PR TITLE
Packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+graft examples
+graft pkgconfig
+graft setup_helpers
+graft src
+include LICENSE
+include README.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[build-system]
+requires=[
+  "setuptools",
+  "numpy",
+]

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     version="0.9.0.post1",
     description="An IPOpt connector for Python",
     long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     author="Gerhard Bräunlich",
     author_email="g.braeunlich@disroot.org",
     url=url,

--- a/setup.py
+++ b/setup.py
@@ -58,5 +58,4 @@ setup(
     url=url,
     ext_modules=LazyList(load_extensions()),
     install_requires=["numpy"],
-    setup_requires=['numpy']
 )


### PR DESCRIPTION
- set content-type on long_description so that the readme is rendered correctly [on pypi.org](https://pypi.org/project/ipyopt/)
- add MANIFEST.in so that setup_helpers and friends are included (otherwise `pip install ipyopt` cannot succeed due to the missing files)
- specify build requirements via pyproject.toml instead of setup_requires (see [PEP 518](https://www.python.org/dev/peps/pep-0518/)). tl;dr is that setup_requires is deprecated and mostly unmaintained, installs with easy_install instead of pip, and is known to fail to install the correct versions of numpy in particular (See [here](https://github.com/jupyter/repo2docker/issues/729#issuecomment-508439282) for a recent example).